### PR TITLE
Add id-token write permission to backup-db workflow

### DIFF
--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -51,6 +51,7 @@ jobs:
         source global_config/${DEPLOY_ENV}.sh
         tf_vars_file=${TF_VARS_PATH}/${DEPLOY_ENV}.tfvars.json
         echo "CLUSTER=$(jq -r '.cluster' ${tf_vars_file})" >> $GITHUB_ENV
+        echo "NAMESPACE=$(jq -r '.namespace' ${tf_vars_file})" >> $GITHUB_ENV
         echo "RESOURCE_GROUP_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-rg" >> $GITHUB_ENV
         echo "STORAGE_ACCOUNT_NAME=${AZURE_RESOURCE_PREFIX}${SERVICE_SHORT}dbbkp${CONFIG_SHORT}sa" >> $GITHUB_ENV
         TODAY=$(date +"%F")
@@ -71,6 +72,7 @@ jobs:
         storage-account: ${{ env.STORAGE_ACCOUNT_NAME }}
         resource-group: ${{ env.RESOURCE_GROUP_NAME }}
         app-name: find-teachers-for-research-${{ env.DEPLOY_ENV }}
+        namespace: ${{ env.NAMESPACE }}
         cluster: ${{ env.CLUSTER }}
         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
         azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/backup-db.yml
+++ b/.github/workflows/backup-db.yml
@@ -34,6 +34,9 @@ jobs:
   backup:
     name: Backup database
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     environment:
       name: ${{ inputs.environment || 'production' }}
     env:


### PR DESCRIPTION
## Context
The backup-db.yml workflow was failing due to two issues. First, it was missing the required id-token: write permissions block, causing OIDC authentication with Azure to fail as it could not fetch a federated token from GitHub. Second, no namespace was specified, causing a Forbidden error when the action tried to search for application pods across the entire cluster scope instead of the correct namespace.

## Changes proposed in this pull request

- Added id-token: write and contents: read permissions to the backup job in backup-db.yml, consistent with how other workflows in this repo handle OIDC authentication (e.g. build-and-deploy.yml).
- Added namespace read dynamically from the environment tfvars config file and passed to the backup-postgres action to scope the pod search to the correct namespace

## Guidance to review
Compare the permissions block added to backup-db.yml against the existing build-and-deploy.yml workflow - they should now match. Check the namespace is being correctly read from the tfvars config file for both development and production environments. No infrastructure or application changes are included, this is a workflow-only fix. Confirmed working against main:
https://github.com/DFE-Digital/Find-Teachers-For-Research/pull/26#issuecomment-4422266483
