### PR TITLE
2683 - GitHub action validate infra remove domains

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -20,12 +20,6 @@ jobs:
           - display: AKS infrastructure
             validation_plan: aks-infra
             terraform_base: terraform/application
-          - display: Domains infrastructure
-            validation_plan: domains-infra
-            terraform_base: terraform/domains/infrastructure
-          - display: Domains environment
-            validation_plan: domains-env
-            terraform_base: terraform/domains/environment_domains
 
     steps:
       - name: Validate ${{ matrix.display }}


### PR DESCRIPTION
### Context

Find Teachers for Schools do not have DNS zones or Front Door so removing the infra validation of those code branches. 

### Changes proposed in this pull request

Remove both domains/environment_domains and domains/infrastructure from validate-infrastructure.yml.

### Guidance to review

Manually test changes by altering terraform/application/config/production.tfvars.json **enable_monitoring** and running locally the following command.
`make production domains-plan CONFIRM_PRODUCTION=yes`
This will produce a Terraform update in place.

To validate the workflow once available (which it now is). Make a test branch (this is such a branch) with a change to terraform/application/config/production.tfvars.json **enable_monitoring**.

Run the workflow against that branch. It must produce a post in the SD Infra Alerts Teams channel with description **Infrastructure Drift Detected in production**.
This will produce a Teams channel card even without a change as the docker image will be different between main and the branch. This can be observed in the Action log file.

### Link to Trello card

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally